### PR TITLE
SetDelegate in MBHttpConnectionOperation

### DIFF
--- a/Classes/MBHTTPConnectionOperation.m
+++ b/Classes/MBHTTPConnectionOperation.m
@@ -21,7 +21,7 @@
 @implementation MBHTTPConnectionOperation
 
 @dynamic error;
-@synthesize delegate = _delegate;
+@dynamic delegate;
 @synthesize successfulStatusCodes = _successfulStatusCodes;
 @synthesize validContentTypes = _validContentTypes;
 


### PR DESCRIPTION
Hey Guys --

When trying to set the uploadProgressCallback on MBBaseRequest, I realized that it wasn't being called. On trying to debug what was going on, I realized the delegate for MBHttpConnectionOperation was not being set, even though the setDelegate message was being passed to the object. 

This seems to because there's an explicit setter being generated by the compiler in MBHTTPConnectionOperation, even when MBURLConnectionOperation already has a setter/getter pair. So, I attempted to fix this issue by directing the compiler to search for the getter/setter pair for the delegate in a superclass versus generate its own, and that seems to have done the trick! 

Obviously, I'm just getting into iOS and could be totally wrong about this. So, do let me know :).

Kunal
