### PR TITLE
Ensuring to release the responseImage

### DIFF
--- a/Classes/MBImageRequest.m
+++ b/Classes/MBImageRequest.m
@@ -31,6 +31,7 @@
 
 - (void)dealloc
 {
+    [_responseImage release];
     [_imageCompletionHandler release];
     [super dealloc];
 }


### PR DESCRIPTION
Not releasing the responseImage seemed to be causing a memory leak as I was downloading images. I think this was only partly the problem, as I was not causing mbimagerequest objects to leak on my end too.
