### PR TITLE
Improvements to MBNetworkActivityIndicatorManager in shared frameworks

### DIFF
--- a/Classes/MBNetworkActivityIndicatorManager.h
+++ b/Classes/MBNetworkActivityIndicatorManager.h
@@ -8,6 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#import <UIKit/UIKit.h>
+#endif
+
 /**
  A class for managing the global network activity indicator on iOS. This class will do nothing on
  OS X. This class is thread-safe and uses GCD to ensure that the network activity indicator is only
@@ -22,6 +26,17 @@
  before any classes call networkActivityStarted or networkActivityStopped.
  */
 @property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+
+
+/**
+ A property for containing the UIApplication whose network activity indicator will be activated
+ when networkActivityStarted and networkActivityStopped are called. Use this property when MBRequest
+ is contained in a framework shared between a containing app and an app extension. Setting this
+ property in your appDelegate will ensure that the network activity indicator is managed properly.
+ */
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+@property (nonatomic, assign) UIApplication *sharedApplication;
+#endif
 
 /**
  Call this whenever network activity is started. Every call to this method must be balanced by a

--- a/Classes/MBNetworkActivityIndicatorManager.m
+++ b/Classes/MBNetworkActivityIndicatorManager.m
@@ -8,10 +8,6 @@
 
 #import "MBNetworkActivityIndicatorManager.h"
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#endif
-
 
 @interface MBNetworkActivityIndicatorManager ()
 @property (nonatomic, assign) NSInteger networkActivityCounter;
@@ -28,6 +24,10 @@
     if (self)
     {
         _enabled = YES;
+        
+#if !defined(APPLICATION_EXTENSION_API_ONLY)
+        _sharedApplication = [UIApplication sharedApplication];
+#endif
     }
     
     return self;
@@ -45,13 +45,13 @@
 
 - (void)networkActivityStarted
 {
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(APPLICATION_EXTENSION_API_ONLY)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
     if ([self isEnabled])
     {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (self.networkActivityCounter == 0)
             {
-                [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+                [[self sharedApplication] setNetworkActivityIndicatorVisible:YES];
             }
             self.networkActivityCounter = self.networkActivityCounter + 1;
         });
@@ -61,13 +61,13 @@
 
 - (void)networkActivityStopped
 {
-#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && !defined(APPLICATION_EXTENSION_API_ONLY)
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
     if ([self isEnabled])
     {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (self.networkActivityCounter == 1)
             {
-                [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+                [[self sharedApplication] setNetworkActivityIndicatorVisible:NO];
             }
             self.networkActivityCounter = self.networkActivityCounter - 1;
         });

--- a/README.md
+++ b/README.md
@@ -87,7 +87,16 @@ MBRequest uses [ARC (Automatic Reference Counting)][ARC]. If you are not using A
 
 ## App Extensions
 
-When using MBRequest in an App Extension, `#define APPLICATION_EXTENSION_API_ONLY` to avoid using unavailable APIs.
+When using MBRequest in an App Extension, `#define APPLICATION_EXTENSION_API_ONLY` to avoid using unavailable APIs. If using MBRequest in both an App Extension and a Containing App, make sure to set the `sharedApplication` property on `MBNetworkActivityIndicatorManager` in your appDelegate to  `[UIApplication sharedApplication]`. Doing so will ensure that the indicator displays properly in your Containing App.
+
+```objc
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    [[MBNetworkActivityIndicatorManager sharedManager] setSharedApplication:[UIApplication sharedApplication]];
+
+    ...
+}
+```
 
 ## Localization
 


### PR DESCRIPTION
I noticed that with my fix, the network activity indicator no longer worked in a containing application. I made some improvements so that the network activity indicator still works properly when used in an extension and a containing app.

Defaults keep things exactly the same for users who do nothing.