### PR TITLE
Make response header fields visible for 'MBHTTPRequest' class

### DIFF
--- a/Classes/MBHTTPRequest.h
+++ b/Classes/MBHTTPRequest.h
@@ -28,6 +28,11 @@ typedef void (^MBHTTPRequestCompletionHandler)(NSData *responseData, NSError *er
 @property (nonatomic, strong, readonly) MBHTTPConnectionOperation *connectionOperation;
 
 /**
+ All the response header fields associated with the request
+ */
+@property (nonatomic, strong, readonly) NSDictionary *responseHeaderFields;
+
+/**
  Performs a basic request and notifies the caller when the request finishes.
  @param request The NSURLRequest to perform.
  @param completionHandler A block to execute after the request finishes. This block will always run

--- a/Classes/MBHTTPRequest.m
+++ b/Classes/MBHTTPRequest.m
@@ -13,6 +13,7 @@
 
 @interface MBHTTPRequest ()
 @property (nonatomic, copy, readwrite) MBHTTPRequestCompletionHandler HTTPCompletionHandler;
+@property (nonatomic, strong, readwrite) NSDictionary *responseHeaderFields;
 @end
 
 @implementation MBHTTPRequest
@@ -33,6 +34,7 @@
 {
     [[self connectionOperation] setRequest:request];
     [self setHTTPCompletionHandler:completionHandler];
+    self.responseHeaderFields = nil;
     [self scheduleOperation];
 }
 
@@ -42,6 +44,7 @@
     
     if ([self HTTPCompletionHandler] != nil)
     {
+        self.responseHeaderFields = self.connectionOperation.response.allHeaderFields;
         [self HTTPCompletionHandler]([[self connectionOperation] responseData], [self error]);
     }
 }


### PR DESCRIPTION
@logancautrell  Expose response header fields. 
Need this for handling LX passKit API response. The API would return a value in the response header indicating whether that data is a single .pkpass file, or a compressed .zip file of multiple .pkpass files.
